### PR TITLE
Replaced deprecated function calls, resolve smarty syntax errors, include url fallback

### DIFF
--- a/eshop/modules/pl/pl_analytics/controllers/admin/pl_analytics_setup.php
+++ b/eshop/modules/pl/pl_analytics/controllers/admin/pl_analytics_setup.php
@@ -78,7 +78,7 @@ class pl_analytics_setup extends oxAdminDetails
      */
     public function save()
     {
-        $aParams = oxConfig::getParameter( "editval" );
+        $aParams = oxRegistry::getConfig()->getRequestParameter( "editval" );
         $oPlAnalytics = $this->getPlAnalytics();
         $oPlAnalytics->changeConfig($aParams);
     }

--- a/eshop/modules/pl/pl_analytics/core/pl_analytics.php
+++ b/eshop/modules/pl/pl_analytics/core/pl_analytics.php
@@ -72,7 +72,7 @@
 
     protected function _loadConfig()
     {
-        $aSavedConfig = oxConfig::getInstance()->getShopConfVar(self::CONFIG_ENTRY_NAME);
+        $aSavedConfig = oxRegistry::getConfig()->getShopConfVar(self::CONFIG_ENTRY_NAME);
         if ($aSavedConfig && count($aSavedConfig) == count($this->_aConfig)) {
             $this->_aConfig = $aSavedConfig;
         }
@@ -84,7 +84,7 @@
 
     protected function _saveConfig()
     {
-        oxConfig::getInstance()->saveShopConfVar( 'arr', self::CONFIG_ENTRY_NAME, $this->_aConfig );
+        oxRegistry::getConfig()->saveShopConfVar( 'arr', self::CONFIG_ENTRY_NAME, $this->_aConfig );
     }
 
     public function getConfig()
@@ -113,7 +113,7 @@
      */
     protected function _getViewOrder()
     {
-        return oxConfig::getInstance()->getActiveView();
+        return oxRegistry::getConfig()->getActiveView();
     }
 
     /**
@@ -191,7 +191,11 @@
      */
     public function getGaDomain()
     {
-        return $this->getConfigValue('ga_domain');
+        $sDomain = "auto";
+        if($this->getConfigValue('ga_domain') != "domain.tld") {
+            $sDomain = $this->getConfigValue('ga_domain');
+        }
+        return $sDomain;
     }
 
     /**
@@ -319,9 +323,9 @@
 		$sPlAnalyticsCode .= "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o)," . "\n";
 		$sPlAnalyticsCode .= "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)" . "\n";
 		$sPlAnalyticsCode .= "})(window,document,'script','//www.google-analytics.com/analytics.js','ga');" . "\n";
-		
+                
         $this->addPushParams('set', 'anonymizeIp', 'true');
-        $this->addPushParams('create', $this->getGaUaId(), $this->getConfigValue('ga_domain'));
+        $this->addPushParams('create', $this->getGaUaId(), $this->getGaDomain());
 		$this->addPushParams('send', 'pageview');
         $this->_setGaParamsByViewObject();
 

--- a/eshop/modules/pl/pl_analytics/views/admin/tpl/pl_analytics_setup.tpl
+++ b/eshop/modules/pl/pl_analytics/views/admin/tpl/pl_analytics_setup.tpl
@@ -1,19 +1,19 @@
 [{include file="headitem.tpl" title="GENERAL_ADMIN_TITLE"|oxmultilangassign}]
-[{ if $readonly }]
-[{assign var="readonly" value="readonly disabled"}]
+[{if $readonly}]
+    [{assign var="readonly" value="readonly disabled"}]
 [{else}]
-[{assign var="readonly" value=""}]
+    [{assign var="readonly" value=""}]
 [{/if}]
-<form name="transfer" id="transfer" action="[{ $oViewConf->getSelfLink() }]" method="post">
-    [{ $oViewConf->getHiddenSid() }]
+<form name="transfer" id="transfer" action="[{$oViewConf->getSelfLink()}]" method="post">
+    [{$oViewConf->getHiddenSid()}]
     <input type="hidden" name="cl" value="pl_analytics_setup">
-    <input type="hidden" name="language" value="[{ $actlang }]">
+    <input type="hidden" name="language" value="[{$actlang}]">
 </form>
-<form name="myedit" id="myedit" action="[{ $oViewConf->getSelfLink() }]" method="post">
-	[{ $oViewConf->getHiddenSid() }]
+<form name="myedit" id="myedit" action="[{$oViewConf->getSelfLink()}]" method="post">
+	[{$oViewConf->getHiddenSid()}]
 	<input type="hidden" name="cl" value="pl_analytics_setup">
 	<input type="hidden" name="fnc" value="">
-	<input type="hidden" name="language" value="[{ $actlang }]">
+	<input type="hidden" name="language" value="[{$actlang}]">
 	<table cellspacing="0" cellpadding="0" border="0" width="98%">
 		<tr>
 			<td valign="top" class="edittext">
@@ -21,7 +21,7 @@
 					[{foreach from=$oView->getConfigValues() item='aConfigValueOptions' key='sConfigKey'}]
 					<tr>
 						<td class="edittext">
-							[{ oxmultilang ident="PL_ANALYTICS_CONFIG_"|cat:$sConfigKey }]
+							[{oxmultilang ident="PL_ANALYTICS_CONFIG_"|cat:$sConfigKey}]
                              
 						</td>
 						<td class="edittext">
@@ -29,7 +29,7 @@
                         
 							<input type="text" class="editinput" size="40" maxlength="255"
                                
-								   name="editval[[{$sConfigKey}]]" value="[{$aConfigValueOptions.value}]" [{ $readonly }]>
+								   name="editval[[{$sConfigKey}]]" value="[{$aConfigValueOptions.value}]" [{$readonly}]>
 							[{/if}]
 							[{if $aConfigValueOptions.input_type == 'select'}]
                              
@@ -41,7 +41,7 @@
 							</select>
                             
 							[{/if}]
-							[{ oxinputhelp ident="HELP_PL_ANALYTICS_CONFIG_"|cat:$sConfigKey }]
+							[{oxinputhelp ident="HELP_PL_ANALYTICS_CONFIG_"|cat:$sConfigKey}]
 						</td>
 					</tr>
 					[{/foreach}]
@@ -52,8 +52,8 @@
 						</td>
 						<td valign="top" class="edittext"><br><br>
 							<input type="submit" class="edittext" id="oLockButton"
-								   value="[{ oxmultilang ident="GENERAL_SAVE" }]"
-								   onclick="Javascript:document.myedit.fnc.value='save'"" [{ $readonly }]><br>
+								   value="[{oxmultilang ident="GENERAL_SAVE"}]"
+								   onclick="Javascript:document.myedit.fnc.value='save' [{$readonly}]><br>
 						</td>
                         
 					</tr>


### PR DESCRIPTION
Replaced deprecated functions to make the module compatible with Oxid CE 4.9.3, resolve smarty syntax errors and include fallback if domain.tld not set to google default value. But even if you set the url it'll not be set. Maybe you want to fix because i think that i dont need it.
